### PR TITLE
A few fixes to prevent 'service' command errors, and creation of 'FILE'

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Usage
 2. Configure the script to match your needs
 2. Login via ssh to test it
 
+`wget https://github.com/IntellexApps/ssh_notify/raw/master/ssh_notify.sh -O /etc/profile.d/ssh_notify.sh && chmod +x /etc/profile.d/ssh_notify.sh`
 
 Credits
 --------------------

--- a/ssh_notify.sh
+++ b/ssh_notify.sh
@@ -105,7 +105,7 @@ PTR=`dig +short -x ${IP} | sed s/\.$//`
 	HISTORY_COUNTER=0
 
 	# Make sure the file exists
-	touch FILE
+	touch $FILE
 
 	# Get the current state
 	if [ -f $FILE ]; then
@@ -195,8 +195,10 @@ fi # }
 if ! [[ $MESSAGE_ENABLED -eq 0 ]]; then
 
 	# Get the services
+	[[ -z $(command -v service) ]] && SVC_CMD="/etc/init.d/" || SVC_CMD="service "
+
 	for SERVICE in ${MESSAGE_SERVICES}; do
-		STATUS=`service ${SERVICE} status 2>&1`
+		STATUS=`${SVC_CMD}${SERVICE} status 2>&1`
 		SERVICES="${SERVICES} ${STATUS}\n"
 	done;
 


### PR DESCRIPTION
I don't really use the service status output myself, but noticed i got some errors stating unknown command or something like that, probably because my user didn't have access to this command on a Debian 8 box.

I also noticed i kept having a file name `FILE` in my homedir.
